### PR TITLE
Update test as filters to stop deprecation notice

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
   when:
     - tinyproxy_required_distro_packages is defined
   register: install_packages
-  until: install_packages | success
+  until: install_packages is success
   retries: 5
   delay: 2
 
@@ -45,7 +45,7 @@
     update_cache: "{{ (ansible_pkg_mgr in ['apt', 'zypper']) | ternary('yes', omit) }}"
     cache_valid_time: "{{ (ansible_pkg_mgr == 'apt') | ternary(cache_timeout, omit) }}"
   register: install_packages
-  until: install_packages | success
+  until: install_packages is success
   notify: Restart tinyproxy
   retries: 5
   delay: 2


### PR DESCRIPTION
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|success` use `result is success`. This feature will be removed in
version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.